### PR TITLE
Feature next & previous commands

### DIFF
--- a/Sources/Retina/Command.swift
+++ b/Sources/Retina/Command.swift
@@ -1,7 +1,8 @@
 import ArgumentParser
 
 enum Command: String, CaseIterable, ExpressibleByArgument {
-    case toggle
+    case previous
+    case next
     case version
 
     init?(argument: String) {

--- a/Sources/Retina/Commands/ToggleCommand.swift
+++ b/Sources/Retina/Commands/ToggleCommand.swift
@@ -3,11 +3,29 @@ enum ToggleCommandError: Error {
 }
 
 enum ToggleCommand {
-    static func run(for display: Display) throws {
-        guard let newResolution = try display.resolutions().first(where: { !$0.current }) else {
-            throw ToggleCommandError.unableToFindNewResolution
+    enum Direction {
+        case next, previous
+    }
+    static func run(for display: Display, direction: Direction) throws {
+        guard let current = try display.resolutions().first(where: { $0.current }) else {
+           throw ToggleCommandError.unableToFindNewResolution
+        }
+        let validResolutions = try display.resolutions().filter({ !$0.current })
+
+        switch direction {
+        case .previous:
+            if let previousResolution = validResolutions.last(where: { $0.width < current.width }) {
+                Display.activate(previousResolution.mode, for: display.id)
+            } else if let lastResolution = validResolutions.last {
+                Display.activate(lastResolution.mode, for: display.id)
+            }
+        case .next:
+            if let nextResolution = validResolutions.first(where: { $0.width > current.width }) {
+                Display.activate(nextResolution.mode, for: display.id)
+            } else if let firstResolution = validResolutions.first {
+                Display.activate(firstResolution.mode, for: display.id)
+            }
         }
 
-        Display.activate(newResolution.mode, for: display.id)
     }
 }

--- a/Sources/Retina/Display.swift
+++ b/Sources/Retina/Display.swift
@@ -10,8 +10,8 @@ struct Display {
     var displayMode: CGDisplayMode
 
     private var validRefreshRates: Set<Double> = [120.0]
-    private var validWidths: Set<Int> = [1512, 1800]
-    private var validHeights: Set<Int> = [982, 1169]
+    private var validWidths: Set<Int> = [1352, 1512, 1800]
+    private var validHeights: Set<Int> = [878, 982, 1169]
 
     /// List all available modes.
     var modes: [CGDisplayMode] {

--- a/Sources/Retina/Retina.swift
+++ b/Sources/Retina/Retina.swift
@@ -14,8 +14,10 @@ struct Retina: ParsableCommand {
     mutating func run() throws {
         let display = try Display()
         switch command {
-        case .toggle:
-            try ToggleCommand.run(for: display)
+        case .previous:
+            try ToggleCommand.run(for: display, direction: .previous)
+        case .next:
+            try ToggleCommand.run(for: display, direction: .next)
         case .version:
             VersionCommand.run()
         }

--- a/Sources/Retina/main.swift
+++ b/Sources/Retina/main.swift
@@ -2,7 +2,7 @@ var arguments = Array(CommandLine.arguments.reversed())
 _ = arguments.popLast()
 
 if arguments.isEmpty {
-    arguments.append(Command.toggle.rawValue)
+    arguments.append(Command.next.rawValue)
 }
 
 Retina.main(arguments)


### PR DESCRIPTION
- Refactor base implementation to use `next` and `previous` commands to
  switch between resolutions
- The toggle command has been removed and the default command is now
  `next` which should render the same result as toggle
- Add support for one additional resolution that gets tagged as being
  valid (1352x878)
- When either `next` or `previous` reaches the beginning or end of the
  valid resolutions list, it will cycle and go to either end
  respectfully
